### PR TITLE
Mypage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:theme="@style/Theme.DuckBox"
         android:usesCleartextTraffic="true">
         <activity
+            android:name=".view.activity.MyPaperActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.activity.ChangeInfoActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.AligatorAPT.DuckBox" >
+    package="com.AligatorAPT.DuckBox">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
@@ -14,7 +14,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DuckBox"
-        android:usesCleartextTraffic="true" >
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".view.activity.AskMasterActivity"
+            android:exported="false" />
         <activity
             android:name=".view.activity.SearchActivity"
             android:exported="false" />
@@ -56,7 +59,7 @@
             android:exported="false" />
         <activity
             android:name=".MainActivity"
-            android:exported="true" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:theme="@style/Theme.DuckBox"
         android:usesCleartextTraffic="true">
         <activity
+            android:name=".view.activity.ChangeInfoActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.activity.PolicyActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
         android:theme="@style/Theme.DuckBox"
         android:usesCleartextTraffic="true">
         <activity
+            android:name=".view.activity.PolicyActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.activity.AskMasterActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/Question.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/Question.kt
@@ -1,0 +1,12 @@
+package com.AligatorAPT.DuckBox.dto.paper
+
+data class Question (
+    val type: QuestionType,
+    val question: String,
+    val candidates: List<String>?
+)
+
+enum class QuestionType {
+    MULTI, // [객관식]
+    LIKERT, // [선형배율]
+}

--- a/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/SurveyDetailDto.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/SurveyDetailDto.kt
@@ -1,0 +1,20 @@
+package com.AligatorAPT.DuckBox.dto.paper
+
+import com.AligatorAPT.DuckBox.view.data.BallotStatus
+import java.util.*
+
+data class SurveyDetailDto (
+    val id: String, // ObjectId
+    var title: String,
+    var content: String,
+    var isGroup: Boolean,
+    var groupId: String?, // groupId(ObjectId) if isGroup is true
+    var owner: String, // owner's nickname
+    var startTime: Date,
+    var finishTime: Date,
+    var status: BallotStatus,
+    var images: List<ByteArray>, // image list
+    var questions: List<Question>,
+    var targets: List<Int>?, // student id. null if isGroup is false or all group member have right to survey
+    var reward: Boolean,
+)

--- a/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/VoteDto.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/dto/paper/VoteDto.kt
@@ -2,7 +2,6 @@ package com.AligatorAPT.DuckBox.view.data
 
 import java.io.Serializable
 import java.util.*
-import kotlin.collections.ArrayList
 
 data class VoteRegisterDto(
     var title: String,

--- a/app/src/main/java/com/AligatorAPT/DuckBox/model/GroupModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/model/GroupModel.kt
@@ -112,4 +112,36 @@ object GroupModel {
         })
     }
 
+    fun getGroupsOfUser(callback: MyGroupCallback){
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+        Log.d("UserToken", userToken)
+
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.GROUP_INTERFACE_SERVICE.getGroupsOfUser(headers).enqueue(object :
+            Callback<List<GroupDetailDto>> {
+            override fun onResponse(
+                call: Call<List<GroupDetailDto>>,
+                response: Response<List<GroupDetailDto>>
+            ) {
+                if(response.isSuccessful){
+                    Log.d("Response:: ", response.body().toString())
+                    callback.apiCallback(true, response.body())
+                }else{
+                    callback.apiCallback(false, null)
+                }
+            }
+
+            override fun onFailure(call: Call<List<GroupDetailDto>>, t: Throwable) {
+                callback.apiCallback(false, null)
+                Log.d(
+                    "onFailure::", "Failed GetAllGroup API call with call: " + call +
+                            " + exception: " + t
+                )
+            }
+
+        })
+    }
+
 }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/model/GroupModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/model/GroupModel.kt
@@ -15,7 +15,7 @@ import retrofit2.Callback
 import retrofit2.Response
 
 object GroupModel {
-    fun register(_groupRegisterDto: GroupRegisterDto, callback: RegisterCallBack){
+    fun register(_groupRegisterDto: GroupRegisterDto, callback: RegisterCallBack) {
         val headers = HashMap<String, String>()
         val userToken = MyApplication.prefs.getString("token", "notExist")
         Log.d("UserToken", userToken)
@@ -51,7 +51,7 @@ object GroupModel {
         })
     }
 
-    fun getAllGroup(callback: MyGroupCallback){
+    fun getAllGroup(callback: MyGroupCallback) {
         val headers = HashMap<String, String>()
         val userToken = MyApplication.prefs.getString("token", "notExist")
         Log.d("UserToken", userToken)
@@ -64,10 +64,10 @@ object GroupModel {
                 call: Call<List<GroupDetailDto>>,
                 response: Response<List<GroupDetailDto>>
             ) {
-                if(response.isSuccessful){
+                if (response.isSuccessful) {
                     Log.d("Response:: ", response.body().toString())
                     callback.apiCallback(true, response.body())
-                }else{
+                } else {
                     callback.apiCallback(false, null)
                 }
             }
@@ -83,7 +83,7 @@ object GroupModel {
         })
     }
 
-    fun updateGroup(_groupUpdateDto: GroupUpdateDto, callback: ApiCallback){
+    fun updateGroup(_groupUpdateDto: GroupUpdateDto, callback: ApiCallback) {
         val headers = HashMap<String, String>()
         val userToken = MyApplication.prefs.getString("token", "notExist")
         Log.d("UserToken", userToken)
@@ -92,12 +92,12 @@ object GroupModel {
         RetrofitClient.GROUP_INTERFACE_SERVICE.updateGroup(
             groupUpdateDto = _groupUpdateDto,
             httpHeaders = headers
-        ).enqueue(object: Callback<ResponseBody>{
+        ).enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                if(response.isSuccessful){
+                if (response.isSuccessful) {
                     Log.d("Response:: ", response.body().toString())
                     callback.apiCallback(true)
-                }else{
+                } else {
                     callback.apiCallback(false)
                 }
             }
@@ -112,7 +112,7 @@ object GroupModel {
         })
     }
 
-    fun getGroupsOfUser(callback: MyGroupCallback){
+    fun getGroupsOfUser(callback: MyGroupCallback) {
         val headers = HashMap<String, String>()
         val userToken = MyApplication.prefs.getString("token", "notExist")
         Log.d("UserToken", userToken)
@@ -125,10 +125,10 @@ object GroupModel {
                 call: Call<List<GroupDetailDto>>,
                 response: Response<List<GroupDetailDto>>
             ) {
-                if(response.isSuccessful){
+                if (response.isSuccessful) {
                     Log.d("Response:: ", response.body().toString())
                     callback.apiCallback(true, response.body())
-                }else{
+                } else {
                     callback.apiCallback(false, null)
                 }
             }
@@ -141,6 +141,37 @@ object GroupModel {
                 )
             }
 
+        })
+    }
+
+    fun searchGroup(_query: String, callback: MyGroupCallback) {
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.GROUP_INTERFACE_SERVICE.searchGroup(
+            httpHeaders = headers, query = _query
+        ).enqueue(object : Callback<ArrayList<GroupDetailDto>> {
+            override fun onResponse(
+                call: Call<ArrayList<GroupDetailDto>>,
+                response: Response<ArrayList<GroupDetailDto>>
+            ) {
+                if (response.isSuccessful) {
+                    Log.d("Response:: ", response.body().toString())
+                    callback.apiCallback(true, response.body())
+                } else {
+                    callback.apiCallback(false, null)
+                }
+            }
+
+            override fun onFailure(call: Call<ArrayList<GroupDetailDto>>, t: Throwable) {
+                callback.apiCallback(false, null)
+                Log.d(
+                    "onFailure::", "Failed GetAllGroup API call with call: " + call +
+                            " + exception: " + t
+                )
+            }
         })
     }
 

--- a/app/src/main/java/com/AligatorAPT/DuckBox/retrofit/interface/GroupInterface.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/retrofit/interface/GroupInterface.kt
@@ -17,7 +17,7 @@ interface GroupInterface {
         @Body groupRegisterDto: GroupRegisterDto
         ): Call<String>
 
-    @GET("/api/v1/group")
+    @GET("/api/v1/group/all")
     fun getAllGroup(
         @HeaderMap httpHeaders: HashMap<String, String>
     ): Call<List<GroupDetailDto>>
@@ -27,4 +27,9 @@ interface GroupInterface {
         @Body groupUpdateDto: GroupUpdateDto,
         @HeaderMap httpHeaders: HashMap<String, String>
     ): Call<ResponseBody>
+
+    @GET("/api/v1/group/my")
+    fun getGroupsOfUser(
+        @HeaderMap httpHeaders: HashMap<String, String>
+    ): Call<List<GroupDetailDto>>
 }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/retrofit/interface/GroupInterface.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/retrofit/interface/GroupInterface.kt
@@ -5,10 +5,7 @@ import com.AligatorAPT.DuckBox.dto.group.GroupRegisterDto
 import com.AligatorAPT.DuckBox.dto.group.GroupUpdateDto
 import okhttp3.ResponseBody
 import retrofit2.Call
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.HeaderMap
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface GroupInterface {
     @POST("/api/v1/group")
@@ -32,4 +29,10 @@ interface GroupInterface {
     fun getGroupsOfUser(
         @HeaderMap httpHeaders: HashMap<String, String>
     ): Call<List<GroupDetailDto>>
+
+    @GET("/api/v1/group/{query}")
+    fun searchGroup(
+        @HeaderMap httpHeaders: HashMap<String, String>,
+        @Path("query") query: String
+    ): Call<ArrayList<GroupDetailDto>>
 }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/AskMasterActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/AskMasterActivity.kt
@@ -1,0 +1,31 @@
+package com.AligatorAPT.DuckBox.view.activity
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.Toast
+import com.AligatorAPT.DuckBox.databinding.ActivityAskMasterBinding
+
+class AskMasterActivity : AppCompatActivity() {
+    lateinit var binding: ActivityAskMasterBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAskMasterBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        init()
+    }
+
+    private fun init(){
+        binding.apply {
+            askBackBtn.setOnClickListener {
+                onBackPressed()
+            }
+
+            askBtn.setOnClickListener {
+                Toast.makeText(this@AskMasterActivity, "전송되었습니다.", Toast.LENGTH_LONG).show()
+                onBackPressed()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/ChangeInfoActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/ChangeInfoActivity.kt
@@ -1,0 +1,38 @@
+package com.AligatorAPT.DuckBox.view.activity
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.AligatorAPT.DuckBox.R
+import com.AligatorAPT.DuckBox.databinding.ActivityChangeInfoBinding
+import com.AligatorAPT.DuckBox.view.fragment.signup.MoreInfoFragment
+import com.AligatorAPT.DuckBox.viewmodel.RegisterViewModel
+
+class ChangeInfoActivity : AppCompatActivity() {
+    lateinit var binding: ActivityChangeInfoBinding
+
+    private val model: RegisterViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityChangeInfoBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        init()
+    }
+
+    private fun init(){
+        model.setIsNew(false)
+
+        val transaction = supportFragmentManager.beginTransaction()
+            .add(R.id.changeInfoFrameLayout, MoreInfoFragment())
+        transaction.commit()
+
+        binding.apply {
+            changeInfoBackBtn.setOnClickListener {
+                onBackPressed()
+            }
+            changeInfoTitle.text = "개인정보변경"
+        }
+    }
+}

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/LoginActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/LoginActivity.kt
@@ -40,6 +40,9 @@ class LoginActivity : AppCompatActivity() {
                                 Log.d("REFRESHTOKEN", MyApplication.prefs.getString("refreshToken", "notExist"))
                                 Log.d("STUDENTID", MyApplication.prefs.getString("studentId","notExist"))
                                 Log.d("DID", MyApplication.prefs.getString("did","notExist"))
+                                //이메일 저장
+                                MyApplication.prefs.setString("email",loginEmail.text.toString())
+
                                 val intent = Intent(this@LoginActivity, NavigationActivity::class.java)
                                 startActivity(intent)
                             }else{

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/MyPaperActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/MyPaperActivity.kt
@@ -1,0 +1,152 @@
+package com.AligatorAPT.DuckBox.view.activity
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.View
+import com.AligatorAPT.DuckBox.databinding.ActivityMyPaperBinding
+import com.AligatorAPT.DuckBox.view.adapter.PaperListAdapter
+import com.AligatorAPT.DuckBox.view.data.BallotStatus
+import com.AligatorAPT.DuckBox.view.data.VoteDetailDto
+import com.google.android.material.tabs.TabLayout
+import java.util.*
+import kotlin.collections.ArrayList
+
+class MyPaperActivity : AppCompatActivity() {
+    lateinit var binding: ActivityMyPaperBinding
+
+    private lateinit var myVoteListAdapter: PaperListAdapter
+    private lateinit var mySurveyListAdapter: PaperListAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMyPaperBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        init()
+    }
+
+    private fun init() {
+        binding.apply {
+            myPaperBackBtn.setOnClickListener {
+                onBackPressed()
+            }
+
+            //my vote list 매니저 등록
+            myVoteListAdapter = PaperListAdapter(setPaperList())
+            myVoteListAdapter.itemClickListener = object : PaperListAdapter.OnItemClickListener {
+                override fun OnItemClick(
+                    holder: PaperListAdapter.MyViewHolder,
+                    view: View,
+                    data: VoteDetailDto,
+                    time: String,
+                    position: Int
+                ) {
+                    // 투표와 설문이 한꺼번에 받아지는 그날 수정하기
+                    if (true) {
+                        val intent = Intent(this@MyPaperActivity, VoteDetailActivity::class.java)
+                        startActivity(intent)
+                    } else {
+                        val intent = Intent(this@MyPaperActivity, PollDetailActivity::class.java)
+                        startActivity(intent)
+                    }
+                }
+            }
+
+            //my survey list 매니저 등록
+            mySurveyListAdapter = PaperListAdapter(arrayListOf())
+            mySurveyListAdapter.itemClickListener = object : PaperListAdapter.OnItemClickListener {
+                override fun OnItemClick(
+                    holder: PaperListAdapter.MyViewHolder,
+                    view: View,
+                    data: VoteDetailDto,
+                    time: String,
+                    position: Int
+                ) {
+                    // 투표와 설문이 한꺼번에 받아지는 그날 수정하기
+                    if (true) {
+                        val intent = Intent(this@MyPaperActivity, VoteDetailActivity::class.java)
+                        startActivity(intent)
+                    } else {
+                        val intent = Intent(this@MyPaperActivity, PollDetailActivity::class.java)
+                        startActivity(intent)
+                    }
+                }
+            }
+
+            myPaperTabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+                override fun onTabSelected(tab: TabLayout.Tab?) {
+                    when (tab!!.position) {
+                        0 -> {
+                            myPaperRecyclerView.adapter = myVoteListAdapter
+
+                            if(myVoteListAdapter.items.size == 0){
+                                emptyMyPaper.visibility = View.VISIBLE
+                                myPaperRecyclerView.visibility = View.GONE
+                            }else{
+                                emptyMyPaper.visibility = View.GONE
+                                myPaperRecyclerView.visibility = View.VISIBLE
+                            }
+                        }
+                        1 -> {
+                            myPaperRecyclerView.adapter = mySurveyListAdapter
+
+                            if(mySurveyListAdapter.items.size == 0){
+                                emptyMyPaper.visibility = View.VISIBLE
+                                myPaperRecyclerView.visibility = View.GONE
+                            }else{
+                                emptyMyPaper.visibility = View.GONE
+                                myPaperRecyclerView.visibility = View.VISIBLE
+                            }
+                        }
+                    }
+                }
+
+                override fun onTabUnselected(tab: TabLayout.Tab?) {
+
+                }
+
+                override fun onTabReselected(tab: TabLayout.Tab?) {
+
+                }
+
+            })
+        }
+    }
+
+    private fun setPaperList(): ArrayList<VoteDetailDto> {
+        return arrayListOf<VoteDetailDto>(
+            VoteDetailDto(
+                id = "1",
+                title = "건국대학교 제47회 공과대학 학생회 투표",
+                content = "KU총학생회",
+                isGroup = true,
+                groupId = "a",
+                owner = "owner",
+                startTime = Date(),
+                finishTime = Date(),
+                status = BallotStatus.OPEN,
+                images = listOf(),
+                candidates = listOf("a", "b"),
+                voters = null,
+                reward = false
+            ),
+            VoteDetailDto(
+                id = "1",
+                title = "건국대학교 제47회 공과대학 학생회 투표",
+                content = "KU총학생회",
+                isGroup = true,
+                groupId = "a",
+                owner = "owner",
+                startTime = Date(),
+                finishTime = Date(),
+                status = BallotStatus.OPEN,
+                images = listOf(),
+                candidates = listOf("a", "b"),
+                voters = null,
+                reward = false
+            ),
+        )
+        return arrayListOf()
+    }
+}

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/PolicyActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/PolicyActivity.kt
@@ -1,0 +1,35 @@
+package com.AligatorAPT.DuckBox.view.activity
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.AligatorAPT.DuckBox.databinding.ActivityPolicyBinding
+
+class PolicyActivity : AppCompatActivity() {
+    lateinit var binding: ActivityPolicyBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPolicyBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        init()
+    }
+
+    private fun init(){
+        val flag = intent.getBooleanExtra("isTerm", true)
+
+        binding.apply {
+            policyBackBtn.setOnClickListener {
+                onBackPressed()
+            }
+
+            if(flag){
+                policyTitle.text = "이용약관"
+                policyText.text = "이용약관"
+            }else{
+                policyTitle.text = "개인정보처리방침"
+                policyText.text = "개인정보처리방침"
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/SearchActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/SearchActivity.kt
@@ -4,14 +4,16 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
-import com.AligatorAPT.DuckBox.R
 import com.AligatorAPT.DuckBox.databinding.ActivitySearchBinding
 import com.AligatorAPT.DuckBox.dto.group.GroupDetailDto
 import com.AligatorAPT.DuckBox.dto.group.GroupStatus
 import com.AligatorAPT.DuckBox.view.adapter.GroupListAdapter
 import com.AligatorAPT.DuckBox.view.adapter.PaperListAdapter
-import com.AligatorAPT.DuckBox.view.data.PaperListData
+import com.AligatorAPT.DuckBox.view.data.BallotStatus
+import com.AligatorAPT.DuckBox.view.data.VoteDetailDto
 import com.google.android.material.tabs.TabLayout
+import java.util.*
+import kotlin.collections.ArrayList
 
 class SearchActivity : AppCompatActivity() {
     private lateinit var myPaperListAdapter: PaperListAdapter
@@ -36,7 +38,7 @@ class SearchActivity : AppCompatActivity() {
 
             searchBtn.setOnClickListener {
                 myPaperListAdapter.setData(setPaperList(0))
-                communityListAdapter.setData(setPaperList(1))
+                communityListAdapter.setData(setPaperList(0))
                 groupListAdapter.setData(setGroupList())
             }
 
@@ -46,11 +48,12 @@ class SearchActivity : AppCompatActivity() {
                 override fun OnItemClick(
                     holder: PaperListAdapter.MyViewHolder,
                     view: View,
-                    data: PaperListData,
+                    data: VoteDetailDto,
+                    time: String,
                     position: Int
                 ) {
-                    // 투표 및 설문 상세로 화면 전환
-                    if (data.isVote) {
+                    // 투표와 설문이 한꺼번에 받아지는 그날 수정하기
+                    if (true) {
                         val intent = Intent(this@SearchActivity, VoteDetailActivity::class.java)
                         startActivity(intent)
                     } else {
@@ -61,16 +64,17 @@ class SearchActivity : AppCompatActivity() {
             }
 
             //community paper list 매니저 등록
-            communityListAdapter = PaperListAdapter(setPaperList(1))
+            communityListAdapter = PaperListAdapter(setPaperList(0))
             communityListAdapter.itemClickListener = object : PaperListAdapter.OnItemClickListener {
                 override fun OnItemClick(
                     holder: PaperListAdapter.MyViewHolder,
                     view: View,
-                    data: PaperListData,
+                    data: VoteDetailDto,
+                    time: String,
                     position: Int
                 ) {
-                    // 투표 및 설문 상세로 화면 전환
-                    if (data.isVote) {
+                    // 투표와 설문이 한꺼번에 받아지는 그날 수정하기
+                    if (true) {
                         val intent = Intent(this@SearchActivity, VoteDetailActivity::class.java)
                         startActivity(intent)
                     } else {
@@ -140,73 +144,39 @@ class SearchActivity : AppCompatActivity() {
         )
     }
 
-    private fun setPaperList(flag: Int): ArrayList<PaperListData> {
+    private fun setPaperList(flag: Int): ArrayList<VoteDetailDto> {
         when (flag) {
             0 -> {
-                return arrayListOf<PaperListData>(
-                    PaperListData(
-                        R.drawable.sub4_color_box_3dp,
-                        "건국대학교 제47회 공과대학 학생회 투표",
-                        "KU총학생회",
-                        true,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
+                return arrayListOf<VoteDetailDto>(
+                    VoteDetailDto(
+                        id = "1",
+                        title = "건국대학교 제47회 공과대학 학생회 투표",
+                        content = "KU총학생회",
+                        isGroup = true,
+                        groupId = "a",
+                        owner = "owner",
+                        startTime = Date(),
+                        finishTime = Date(),
+                        status = BallotStatus.OPEN,
+                        images = listOf(),
+                        candidates = listOf("a", "b"),
+                        voters = null,
+                        reward = false
                     ),
-                    PaperListData(
-                        R.drawable.sub1_color_box_3dp,
-                        "건국대학교 제47회 공과대학 학생회 투표",
-                        "KU총학생회",
-                        true,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
-                    ),
-                    PaperListData(
-                        R.drawable.sub2_color_box_3dp,
-                        "건국대학교 제47회 공과대학 학생회 투표",
-                        "KU총학생회",
-                        true,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
-                    ),
-                    PaperListData(
-                        R.drawable.sub5_color_box_3dp,
-                        "건국대학교 제47회 공과대학 학생회 투표",
-                        "KU총학생회",
-                        true,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
-                    ),
-                )
-            }
-            1 -> {
-                return arrayListOf<PaperListData>(
-                    PaperListData(
-                        R.drawable.sub5_color_box_3dp,
-                        "남녀사이에 친구가 있다 없다?",
-                        "난없다",
-                        true,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
-                    ),
-                    PaperListData(
-                        R.drawable.sub1_color_box_3dp,
-                        "가장 좋아하는 운동은?",
-                        "운린이",
-                        false,
-                        true,
-                        "3일 06:05:03 남음",
-                        100,
-                        50
+                    VoteDetailDto(
+                        id = "1",
+                        title = "건국대학교 제47회 공과대학 학생회 투표",
+                        content = "KU총학생회",
+                        isGroup = true,
+                        groupId = "a",
+                        owner = "owner",
+                        startTime = Date(),
+                        finishTime = Date(),
+                        status = BallotStatus.OPEN,
+                        images = listOf(),
+                        candidates = listOf("a", "b"),
+                        voters = null,
+                        reward = false
                     ),
                 )
             }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/SignUpActivity.kt
@@ -1,15 +1,19 @@
 package com.AligatorAPT.DuckBox.view.activity
 
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.AligatorAPT.DuckBox.R
 import com.AligatorAPT.DuckBox.databinding.ActivitySignUpBinding
 import com.AligatorAPT.DuckBox.view.fragment.signup.*
+import com.AligatorAPT.DuckBox.viewmodel.RegisterViewModel
 
 class SignUpActivity : FragmentActivity() {
     lateinit var binding: ActivitySignUpBinding
     var isTermOfUse = true
+
+    private val model: RegisterViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,6 +24,8 @@ class SignUpActivity : FragmentActivity() {
     }
 
     private fun init() {
+        model.setIsNew(true)
+
         val transaction = supportFragmentManager.beginTransaction()
             .add(R.id.signUpFrameLayout, EmailFragment())
         transaction.commit()

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/adapter/GroupListAdapter.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/adapter/GroupListAdapter.kt
@@ -45,7 +45,7 @@ class GroupListAdapter (var items:ArrayList<GroupDetailDto>)
     override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
         if(items[position].profile == ""){
             //기본 이미지 설정
-            holder.binding.searchGroupImage.setImageResource(R.drawable.banner1)
+            holder.binding.searchGroupImage.setImageResource(R.drawable.user_default)
         }else{
             val decodedImageBytes: ByteArray = Base64.decode(items[position].profile, Base64.DEFAULT)
             val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/adapter/PaperListAdapter.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/adapter/PaperListAdapter.kt
@@ -11,7 +11,6 @@ import android.util.Log
 import com.AligatorAPT.DuckBox.R
 import com.AligatorAPT.DuckBox.databinding.RowPaperBinding
 import com.AligatorAPT.DuckBox.view.data.VoteDetailDto
-import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -41,14 +40,25 @@ class PaperListAdapter(var items: ArrayList<VoteDetailDto>) :
         return items.size
     }
 
+    fun setData(newData:ArrayList<VoteDetailDto>){
+        items.clear()
+        items.addAll(newData)
+        notifyDataSetChanged()
+    }
+
     override fun onBindViewHolder(holder: PaperListAdapter.MyViewHolder, position: Int) {
         holder.binding.apply {
             Log.e("PAPERLISTADPATER",items[position].toString())
             paperListWriter.text = items[position].owner
 
-            val decodedImageBytes = Base64.decode(items[position].images[0], Base64.DEFAULT);
-            val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
-            holder.binding.paperListImage.setImageBitmap(bitmap)
+            if(items[position].images.isEmpty()){
+                //기본 이미지 설정
+                holder.binding.paperListImage.setImageResource(R.drawable.sub1_color_box_5dp)
+            }else{
+                val decodedImageBytes: ByteArray = Base64.decode(items[position].images[0], Base64.DEFAULT)
+                val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
+                holder.binding.paperListImage.setImageBitmap(bitmap)
+            }
 
             paperListCanParticipate.text = "참여 가능"
             paperListCanParticipate.setBackgroundResource(R.drawable.sub1_color_box_3dp)

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupUpdateFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupUpdateFragment.kt
@@ -67,14 +67,15 @@ class GroupUpdateFragment : Fragment() {
             //이미지
             model.profile.observe(viewLifecycleOwner, Observer {
                 if(it != null){
-                    oldProfile = it
+                    if(it.isEmpty()){
+                        groupImage.setImageResource(R.drawable.user_default)
+                    }else{
+                        oldProfile = it
 
-                    val bmp = BitmapFactory.decodeByteArray(it, 0, it.size)
-                    groupImage.setImageBitmap(bmp)
-                    newProfile = bmp
-                }else{
-                    val bmp = BitmapFactory.decodeResource(mActivity.resources, R.drawable.sub2_color_box_3dp)
-                    groupImage.setImageBitmap(bmp)
+                        val bmp = BitmapFactory.decodeByteArray(it, 0, it.size)
+                        groupImage.setImageBitmap(bmp)
+                        newProfile = bmp
+                    }
                 }
             })
 
@@ -87,8 +88,7 @@ class GroupUpdateFragment : Fragment() {
                     newHeader = bmp
 
                 }else{
-                    val bmp = BitmapFactory.decodeResource(mActivity.resources, R.drawable.sub1_color_box_5dp)
-                    groupBackground.setImageBitmap(bmp)
+                    groupBackground.setImageResource(R.drawable.sub1_color_box_5dp)
                 }
             })
 

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupUpdateFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupUpdateFragment.kt
@@ -68,20 +68,27 @@ class GroupUpdateFragment : Fragment() {
             model.profile.observe(viewLifecycleOwner, Observer {
                 if(it != null){
                     oldProfile = it
+
                     val bmp = BitmapFactory.decodeByteArray(it, 0, it.size)
                     groupImage.setImageBitmap(bmp)
+                    newProfile = bmp
                 }else{
-                    groupImage.setImageResource(R.drawable.sub2_color_box_3dp)
+                    val bmp = BitmapFactory.decodeResource(mActivity.resources, R.drawable.sub2_color_box_3dp)
+                    groupImage.setImageBitmap(bmp)
                 }
             })
 
             model.header.observe(viewLifecycleOwner, Observer {
                 if(it != null){
                     oldHeader = it
+
                     val bmp = BitmapFactory.decodeByteArray(it, 0, it.size)
                     groupBackground.setImageBitmap(bmp)
+                    newHeader = bmp
+
                 }else{
-                    groupBackground.setImageResource(R.drawable.sub1_color_box_5dp)
+                    val bmp = BitmapFactory.decodeResource(mActivity.resources, R.drawable.sub1_color_box_5dp)
+                    groupBackground.setImageBitmap(bmp)
                 }
             })
 

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/HomeFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/HomeFragment.kt
@@ -53,11 +53,11 @@ class HomeFragment : Fragment() {
 
     private fun init(){
         //내 그룹 리스트 가져오기
-        model!!.getAllGroup(object: MyGroupCallback{
+        model!!.getGroupsOfUserGroup(object: MyGroupCallback{
             override fun apiCallback(flag: Boolean, _list: List<GroupDetailDto>?) {
                 if(_list != null){
                     model.setMyGroup(_list)
-                    if(_list.size != 0){
+                    if(_list.isNotEmpty()){
                         binding.apply {
                             recyclerMyGroup.visibility = View.VISIBLE
                             emptyGroup1.visibility = View.GONE
@@ -108,7 +108,7 @@ class HomeFragment : Fragment() {
             }
 
             //MyGroup list 관리하는 메니저 등록
-            model!!.myGroup.observe(viewLifecycleOwner, Observer {
+            model.myGroup.observe(viewLifecycleOwner, Observer {
                 if (it != null) {
                     Log.d("MYGROUP", it.toString())
                     val arrayList = ArrayList<GroupDetailDto>()

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
@@ -1,17 +1,83 @@
 package com.AligatorAPT.DuckBox.view.fragment.navigation
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.AligatorAPT.DuckBox.R
+import com.AligatorAPT.DuckBox.databinding.FragmentMyBinding
+import com.AligatorAPT.DuckBox.sharedpreferences.MyApplication
+import com.AligatorAPT.DuckBox.view.activity.AskMasterActivity
+import com.AligatorAPT.DuckBox.view.activity.NavigationActivity
+import com.AligatorAPT.DuckBox.view.dialog.ModalDialog
 
 class MyFragment : Fragment() {
+    private var _binding: FragmentMyBinding? = null
+    private val binding: FragmentMyBinding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_my, container, false)
+        _binding = FragmentMyBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        init()
+    }
+
+    private fun init(){
+        val mActivity = activity as NavigationActivity
+
+        binding.apply {
+            email.text = MyApplication.prefs.getString("email", "notExist")
+            nickname.text = MyApplication.prefs.getString("nickname","notExist")
+
+            myPaper.setOnClickListener {
+
+            }
+
+            changeInfo.setOnClickListener {
+
+            }
+
+            termsOfUseBtn.setOnClickListener {
+
+            }
+
+            privacyPolicyBtn.setOnClickListener {
+
+            }
+
+            askMaster.setOnClickListener {
+
+            }
+
+            logout.setOnClickListener {
+                //다이얼로그
+                val bundle = Bundle()
+                bundle.putString("message", "로그아웃 하시겠습니까?\n 데이터는 해당 계정에 저장됩니다.")
+                val modalDialog = ModalDialog()
+                modalDialog.arguments = bundle
+                modalDialog.itemClickListener = object : ModalDialog.OnItemClickListener{
+                    override fun OnPositiveClick() {
+                        modalDialog.dismiss()
+                    }
+
+                    override fun OnNegativeClick() {
+                        modalDialog.dismiss()
+                    }
+                }
+                modalDialog.show(mActivity.supportFragmentManager, "ModalDialog")
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import com.AligatorAPT.DuckBox.databinding.FragmentMyBinding
 import com.AligatorAPT.DuckBox.sharedpreferences.MyApplication
 import com.AligatorAPT.DuckBox.view.activity.AskMasterActivity
+import com.AligatorAPT.DuckBox.view.activity.ChangeInfoActivity
 import com.AligatorAPT.DuckBox.view.activity.NavigationActivity
 import com.AligatorAPT.DuckBox.view.activity.PolicyActivity
 import com.AligatorAPT.DuckBox.view.dialog.ModalDialog
@@ -42,7 +43,8 @@ class MyFragment : Fragment() {
             }
 
             changeInfo.setOnClickListener {
-
+                val intent = Intent(mActivity, ChangeInfoActivity::class.java)
+                startActivity(intent)
             }
 
             termsOfUseBtn.setOnClickListener {

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
@@ -8,10 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.AligatorAPT.DuckBox.databinding.FragmentMyBinding
 import com.AligatorAPT.DuckBox.sharedpreferences.MyApplication
-import com.AligatorAPT.DuckBox.view.activity.AskMasterActivity
-import com.AligatorAPT.DuckBox.view.activity.ChangeInfoActivity
-import com.AligatorAPT.DuckBox.view.activity.NavigationActivity
-import com.AligatorAPT.DuckBox.view.activity.PolicyActivity
+import com.AligatorAPT.DuckBox.view.activity.*
 import com.AligatorAPT.DuckBox.view.dialog.ModalDialog
 
 class MyFragment : Fragment() {
@@ -39,7 +36,8 @@ class MyFragment : Fragment() {
             nickname.text = MyApplication.prefs.getString("nickname","notExist")
 
             myPaper.setOnClickListener {
-
+                val intent = Intent(mActivity, MyPaperActivity::class.java)
+                startActivity(intent)
             }
 
             changeInfo.setOnClickListener {

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/MyFragment.kt
@@ -10,6 +10,7 @@ import com.AligatorAPT.DuckBox.databinding.FragmentMyBinding
 import com.AligatorAPT.DuckBox.sharedpreferences.MyApplication
 import com.AligatorAPT.DuckBox.view.activity.AskMasterActivity
 import com.AligatorAPT.DuckBox.view.activity.NavigationActivity
+import com.AligatorAPT.DuckBox.view.activity.PolicyActivity
 import com.AligatorAPT.DuckBox.view.dialog.ModalDialog
 
 class MyFragment : Fragment() {
@@ -45,15 +46,20 @@ class MyFragment : Fragment() {
             }
 
             termsOfUseBtn.setOnClickListener {
-
+                val intent = Intent(mActivity, PolicyActivity::class.java)
+                intent.putExtra("isTerm", true)
+                startActivity(intent)
             }
 
             privacyPolicyBtn.setOnClickListener {
-
+                val intent = Intent(mActivity, PolicyActivity::class.java)
+                intent.putExtra("isTerm", false)
+                startActivity(intent)
             }
 
             askMaster.setOnClickListener {
-
+                val intent = Intent(mActivity, AskMasterActivity::class.java)
+                startActivity(intent)
             }
 
             logout.setOnClickListener {

--- a/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/GroupViewModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/GroupViewModel.kt
@@ -46,8 +46,8 @@ class GroupViewModel: ViewModel() {
         _id:String,
         _status:GroupStatus){
 
-        val profileByte: ByteArray = Base64.decode(_header, Base64.DEFAULT)
-        val headerByte: ByteArray = Base64.decode(_profile, Base64.DEFAULT)
+        val profileByte: ByteArray = Base64.decode(_profile, Base64.DEFAULT)
+        val headerByte: ByteArray = Base64.decode(_header, Base64.DEFAULT)
 
         name.value = _name
         leader.value = _leader

--- a/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/HomeViewModel.kt
@@ -28,7 +28,7 @@ class HomeViewModel:ViewModel() {
 
         viewModelScope.launch {
             withContext(dispatcher){
-                GroupModel.getAllGroup( //컨트랙트 연결 후 getGroupsOfUser로 변경하기
+                GroupModel.getGroupsOfUser( //컨트랙트 연결 후 getGroupsOfUser로 변경하기
                     callback = _callback,
                 )
             }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/HomeViewModel.kt
@@ -22,13 +22,13 @@ class HomeViewModel:ViewModel() {
         myGroup.value = _list
     }
 
-    fun getAllGroup(_callback: MyGroupCallback){
+    fun getGroupsOfUserGroup(_callback: MyGroupCallback){
         val hashMap = HashMap<String, String>()
         hashMap.put("token", MyApplication.prefs.getString("token", "notExist"))
 
         viewModelScope.launch {
             withContext(dispatcher){
-                GroupModel.getAllGroup(
+                GroupModel.getAllGroup( //컨트랙트 연결 후 getGroupsOfUser로 변경하기
                     callback = _callback,
                 )
             }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/RegisterViewModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/RegisterViewModel.kt
@@ -19,6 +19,12 @@ class RegisterViewModel: ViewModel(){
     val email = MutableLiveData<String>()
     val nickname = MutableLiveData<String>()
 
+    val isNew = MutableLiveData<Boolean>()
+
+    fun setIsNew(_isNew: Boolean){
+        isNew.value = _isNew
+    }
+
     fun setEmail(_email:String){
         email.value = _email
     }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/viewmodel/SearchViewModel.kt
@@ -1,0 +1,38 @@
+package com.AligatorAPT.DuckBox.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.AligatorAPT.DuckBox.dto.group.GroupDetailDto
+import com.AligatorAPT.DuckBox.model.GroupModel
+import com.AligatorAPT.DuckBox.retrofit.callback.MyGroupCallback
+import com.AligatorAPT.DuckBox.sharedpreferences.MyApplication
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+
+class SearchViewModel:ViewModel() {
+    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+    //내 그룹 리스트
+    var groupList = MutableLiveData<List<GroupDetailDto>?>()
+
+    fun setGroupList(_list: List<GroupDetailDto>){
+        groupList.value = _list
+    }
+
+    fun searchGroup(query:String, _callback: MyGroupCallback){
+        val hashMap = HashMap<String, String>()
+        hashMap.put("token", MyApplication.prefs.getString("token", "notExist"))
+
+        viewModelScope.launch {
+            withContext(dispatcher){
+                GroupModel.searchGroup(
+                    _query = query,
+                    callback = _callback,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_ask_master.xml
+++ b/app/src/main/res/layout/activity_ask_master.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".view.fragment.navigation.AlarmFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/askBackBtn"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="30dp"
+            android:contentDescription="backBtn"
+            android:src="@drawable/back" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:gravity="center"
+            android:paddingVertical="24dp"
+            android:text="문의하기"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+    <EditText
+        android:autofillHints="false"
+        android:id="@+id/askContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="26dp"
+        android:layout_marginBottom="11dp"
+        android:background="@drawable/sub1_color_box_10dp"
+        android:ems="10"
+        android:gravity="start|top"
+        android:hint="문의 사항을 입력해주세요."
+        android:inputType="textMultiLine"
+        android:lines="8"
+        android:paddingHorizontal="30dp"
+        android:paddingVertical="26dp"
+        android:scrollHorizontally="false"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/askBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:background="@drawable/main_color_box_10dp"
+        android:gravity="center"
+        android:paddingVertical="14dp"
+        android:text="전송하기"
+        android:textColor="@color/white"
+        android:textSize="16sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_change_info.xml
+++ b/app/src/main/res/layout/activity_change_info.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".view.activity.ChangeInfoActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/changeInfoBackBtn"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="30dp"
+            android:contentDescription="backBtn"
+            android:src="@drawable/back" />
+
+        <TextView
+            android:id="@+id/changeInfoTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:gravity="center"
+            android:paddingVertical="24dp"
+            android:text="이메일 인증하기"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/changeInfoFrameLayout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+    </FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_my_paper.xml
+++ b/app/src/main/res/layout/activity_my_paper.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".view.activity.MyPaperActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/myPaperBackBtn"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="30dp"
+            android:contentDescription="backBtn"
+            android:src="@drawable/back" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:gravity="center"
+            android:paddingVertical="24dp"
+            android:text="생성한 투표 및 설문"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/myPaperTabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="28dp"
+        app:tabIndicatorColor="@color/main"
+        app:tabSelectedTextColor="@color/main"
+        app:tabTextColor="@color/darkgray2">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="투표" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="설문" />
+    </com.google.android.material.tabs.TabLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/myPaperRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:visibility="visible"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/row_paper" />
+
+    <LinearLayout
+        android:id="@+id/emptyMyPaper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:contentDescription="LOGO"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="26dp"
+            app:srcCompat="@drawable/duck_main" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="생성 내역이 없어요."
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_policy.xml
+++ b/app/src/main/res/layout/activity_policy.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".view.activity.PolicyActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/policyBackBtn"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="30dp"
+            android:contentDescription="backBtn"
+            android:src="@drawable/back" />
+
+        <TextView
+            android:id="@+id/policyTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="40dp"
+            android:gravity="center"
+            android:paddingVertical="24dp"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="25dp"
+        android:background="@drawable/gray_color_box_5dp"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/policyText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="이용약관" />
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -89,6 +89,83 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
+        android:visibility="visible"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    <LinearLayout
+        android:id="@+id/emptyResult"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:contentDescription="LOGO"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            app:srcCompat="@drawable/duck_main" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:gravity="center"
+            android:text="검색 결과가 없어요"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="다른 키워드로 검색해보세요."
+            android:textColor="@color/black"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="30dp"
+            android:layout_marginTop="60dp"
+            android:background="@drawable/gray_color_box_5dp"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="이렇게 해보세요."
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="-키워드를 정확하게 입력하셨는지 확인해보세요."
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="-일반적인 키워드로 검색해보세요. (예: 오리상자 → 오리)"
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="-그룹 알림을 통해 검색을 하지 않고도 새로운 투표와 설문을 확인할 수 있어요."
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+        </LinearLayout>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -83,7 +83,8 @@
                 android:layout_marginBottom="5dp"
                 android:text="가입한 그룹이 없어요"
                 android:textColor="@color/black"
-                android:textSize="18sp" />
+                android:textSize="18sp"
+                android:visibility="invisible" />
 
             <TextView
                 android:id="@+id/emptyGroup2"
@@ -93,7 +94,8 @@
                 android:layout_marginBottom="47dp"
                 android:text="새로운 그룹을 만들거나 가입해보세요."
                 android:textColor="@color/black"
-                android:textSize="12sp" />
+                android:textSize="12sp"
+                android:visibility="invisible" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_more_info.xml
+++ b/app/src/main/res/layout/fragment_more_info.xml
@@ -21,6 +21,7 @@
             android:paddingTop="46dp">
 
             <TextView
+                android:id="@+id/title1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="마지막 단계입니다"
@@ -29,6 +30,7 @@
                 android:textStyle="bold" />
 
             <TextView
+                android:id="@+id/title2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="34dp"

--- a/app/src/main/res/layout/fragment_my.xml
+++ b/app/src/main/res/layout/fragment_my.xml
@@ -1,13 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".view.fragment.navigation.MyFragment">
 
-    <TextView
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="마이페이지" />
+        android:layout_height="wrap_content"
+        android:background="@color/sub1"
+        android:orientation="horizontal"
+        android:paddingHorizontal="28dp"
+        android:paddingVertical="18dp">
 
-</FrameLayout>
+        <ImageView
+            android:contentDescription="LOGO"
+            android:layout_width="70dp"
+            android:layout_height="70dp"
+            android:layout_marginEnd="14dp"
+            android:src="@drawable/duck_main" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/nickname"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:textColor="@color/black"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/black" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/myPaper"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="생성한 투표 및 설문"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/changeInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="개인정보 변경"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/termsOfUseBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="이용약관"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/privacyPolicyBtn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="개인정보처리방침"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/askMaster"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="문의하기"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/logout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/border_bottom"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="25dp"
+        android:text="로그아웃"
+        android:textColor="@color/black"
+        android:textSize="14sp" />
+</LinearLayout>


### PR DESCRIPTION
## 개요
- 마이페이지 구현 및 여러 오류 수정

## 상세
- 이전 pr을 합치면서 발생한 `PaperListAdapter`의 데이터 타입 통일
- 내 그룹 가져오는 api의 endpoint 변경 ~~(서버의 변경에 따라 추후 변경될 것)~~ `수정완료`
- 그룹 업데이트에서 발생한 이미지 오류 코드를 수정
- 그룹 검색 api 연결
- 마이페이지의 각 기능 구현 (로그아웃, 문의하기, 이용약관, 개인정보처리방침, 개인정보변경, 내가 작성한 paper 리스트)


## 리뷰어가 확인할 사항
- 개인정보 변경은 회원가입에서 사용한 fragment를 재사용했습니다.
- 투표와 설문의 통합 과정에 대한 논의가 필요합니다.

## 기타
- 추가 api가 필요합니다! (내가 작성한 투표\설문, 개인정보 변경, 로그아웃, 문의하기, 투표\설문 검색) 
