### PR TITLE
feat: check vote whether it's group or community by groupId

### DIFF
--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/CreateSurveyActivity.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/activity/CreateSurveyActivity.kt
@@ -48,7 +48,6 @@ class CreateSurveyActivity : AppCompatActivity() {
         viewModel.isVote.value = false
         binding.createSurveyLayout.setBackgroundColor(ContextCompat.getColor(this,R.color.create))
 
-        viewModel.isVote.value = false
         surveyRegisterDto.isGroup = intent.getBooleanExtra("isGroup",false)
         if(surveyRegisterDto.isGroup){
             viewModel.setGroup(surveyRegisterDto.isGroup, intent.getStringExtra("groupId"))

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupDetailFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/group/GroupDetailFragment.kt
@@ -242,10 +242,10 @@ class GroupDetailFragment : Fragment() {
         when(flag){
             0->{//투표
                 voteModel!!.getAllVote(object: VoteCallback {
-                    override fun apiCallback(flag: Boolean, _list: ArrayList<VoteDetailDto>?) {
+                    override fun apiCallback(flag: Boolean, _list: List<VoteDetailDto>?) {
                         if(flag && _list != null){
-                            for(i in 0 until _list.size){
-                                if(_list[i].isGroup) {
+                            for(i in _list.indices){
+                                if(_list[i].groupId != null) {
                                     groupList.add(_list[i])
                                 }
                             }
@@ -257,10 +257,10 @@ class GroupDetailFragment : Fragment() {
             }
             1->{//설문
                 voteModel!!.getAllVote(object: VoteCallback{
-                    override fun apiCallback(flag: Boolean, _list: ArrayList<VoteDetailDto>?) {
+                    override fun apiCallback(flag: Boolean, _list: List<VoteDetailDto>?) {
                         if(flag && _list != null){
-                            for(i in 0 until _list.size){
-                                if(_list[i].isGroup) {
+                            for(i in _list.indices){
+                                if(_list[i].groupId != null) {
                                     groupList.add(_list[i])
                                 }
                             }
@@ -271,10 +271,10 @@ class GroupDetailFragment : Fragment() {
             }
             2->{//참여 완료
                 voteModel!!.getAllVote(object: VoteCallback{
-                    override fun apiCallback(flag: Boolean, _list: ArrayList<VoteDetailDto>?) {
+                    override fun apiCallback(flag: Boolean, _list: List<VoteDetailDto>?) {
                         if(flag && _list != null){
-                            for(i in 0 until _list.size){
-                                if(_list[i].isGroup) {
+                            for(i in _list.indices){
+                                if(_list[i].groupId != null) {
                                     groupList.add(_list[i])
                                 }
                             }

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/CommunityFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/CommunityFragment.kt
@@ -146,8 +146,8 @@ class CommunityFragment : Fragment() {
             override fun apiCallback(flag: Boolean, _list: List<VoteDetailDto>?) {
                 if(flag && _list != null){
                     Log.e("COMMUNITY",_list.toString())
-                    for(i in 0 until _list.size){
-                        if(!_list[i].isGroup){
+                    for(i in _list.indices){
+                        if(_list[i].groupId == null) {
                             if(toggleFlag){
                                 //참여함
                             }else{

--- a/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/HomeFragment.kt
+++ b/app/src/main/java/com/AligatorAPT/DuckBox/view/fragment/navigation/HomeFragment.kt
@@ -209,8 +209,8 @@ class HomeFragment : Fragment() {
             override fun apiCallback(flag: Boolean, _list: List<VoteDetailDto>?) {
                 if(flag && _list != null){
                     Log.e("HOME",_list.toString())
-                    for(i in 0 until _list.size){
-                        if(_list[i].isGroup){
+                    for(i in _list.indices){
+                        if(_list[i].groupId != null) {
                             if(toggleFlag){
                                 //참여함
                             }else{


### PR DESCRIPTION
## 개요
- 그룹 투표 생성 시 커뮤니티 투표로 분류되는 오류

## 상세
- 기존엔 `isGroup`이 true 인 경우 그룹투표인 것으로 분류했지만, `groupId`가 null이 아닌 경우 그룹 투표로 분류하도록 수정

## 리뷰어가 확인할 사항
- 투표와 설문 Dto를 아직 합치지 않아 현재는 생성된 투표만 볼 수 있습니다.
- 데이터를 가져오는데 시간이 걸려, 이전의 값들이 recyclerview에 보이게 됩니다. 몇 초 후 데이터가 갱신되어 보입니다. 
